### PR TITLE
修复使用IO Stream 复制Jar中的 module-info.class(Java 9) 文件而导致复制后的文件大小为0B的问题

### DIFF
--- a/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/StringFogClassInjector.java
+++ b/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/StringFogClassInjector.java
@@ -106,21 +106,18 @@ public final class StringFogClassInjector {
 
     private void processClass(InputStream classIn, OutputStream classOut) throws IOException {
         ClassReader cr = new ClassReader(classIn);
+        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        final ClassVisitor cv;
         // skip module-info class, fixed #38
         if ("module-info".equals(cr.getClassName())) {
-            byte[] buffer = new byte[1024];
-            int read;
-            while ((read = classIn.read(buffer)) >= 0) {
-                classOut.write(buffer, 0, read);
-            }
+            cv = cw;
         } else {
-            ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-            ClassVisitor cv = ClassVisitorFactory.create(mStringFogImpl, mMappingPrinter, mFogPackages,
+            cv = ClassVisitorFactory.create(mStringFogImpl, mMappingPrinter, mFogPackages,
                     mKeyGenerator, mFogClassName, cr.getClassName() , mMode, cw);
-            cr.accept(cv, 0);
-            classOut.write(cw.toByteArray());
-            classOut.flush();
         }
+        cr.accept(cv, 0);
+        classOut.write(cw.toByteArray());
+        classOut.flush();
     }
 
     private boolean shouldExcludeJar(File jarIn) throws IOException {


### PR DESCRIPTION
 针对module-info.class(Java 9)文件，StringFog使用IO Stream 复制该文件的策略忽略对该文件的处理，但是经过测试，使用IO Stream去复制module-info.class(Java 9)文件后，复制后的文件大小为**0B**, 目前没有找到具体原因,。

> $ du -h stream_25_jar/META-INF/versions/9/module-info.class
   0B	 stream_25_jar/META-INF/versions/9/module-info.class

后续我使用ASM ClassReader/ClassWriter的方式去复制module-info.class(Java 9)文件，结果是复合预期的。
> $ du -h asm_25_jar/META-INF/versions/9/module-info.class
   4.0K asm_25_jar/META-INF/versions/9/module-info.class`

**[#56]这个问题应该也是这个原因导致的**

我已经结合https://github.com/MegatronKing/StringFog-Sample1 Demo项目复合构建验证通过，请Review。