### PR TITLE
fix bugs caused by multiple configurations

### DIFF
--- a/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/-StringFogExtension.kt
+++ b/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/-StringFogExtension.kt
@@ -1,0 +1,89 @@
+package com.github.megatronking.stringfog.plugin
+
+import com.android.build.api.instrumentation.AsmClassVisitorFactory
+import com.android.build.api.instrumentation.ClassContext
+import com.android.build.api.instrumentation.ClassData
+import com.android.build.api.instrumentation.InstrumentationParameters
+import com.android.build.api.instrumentation.InstrumentationScope
+import com.android.build.api.variant.Instrumentation
+import com.github.megatronking.stringfog.IKeyGenerator
+import com.github.megatronking.stringfog.StringFogWrapper
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.objectweb.asm.ClassVisitor
+import java.io.Serializable
+
+class StringFogExtensionWrapper(
+    val packageName: String,
+    val implementation: String,
+    val generator: IKeyGenerator,
+    val mode: StringFogMode,
+    val enable: Boolean,
+    val debug: Boolean,
+    val fogPackages: Array<String>
+) : Serializable {
+
+    companion object {
+        fun get(extension: StringFogExtension): StringFogExtensionWrapper {
+            return StringFogExtensionWrapper(
+                extension.packageName.orEmpty(),
+                extension.implementation.orEmpty(),
+                extension.kg,
+                extension.mode,
+                extension.enable,
+                extension.debug,
+                extension.fogPackages
+            )
+        }
+    }
+
+}
+
+interface StringForParameters : InstrumentationParameters {
+
+    @get:Input val logs: ListProperty<String>
+
+    @get:Input val className: Property<String>
+
+    @get:Input val extension: Property<StringFogExtensionWrapper>
+
+}
+
+abstract class SimpleStringFogClassVisitorFactory : AsmClassVisitorFactory<StringForParameters> {
+
+    override fun createClassVisitor(
+        classContext: ClassContext, nextClassVisitor: ClassVisitor
+    ): ClassVisitor {
+        val logs = parameters.get().logs.get()
+        val extension = parameters.get().extension.get()
+        val className = parameters.get().className.get()
+        return ClassVisitorFactory.create(
+            StringFogWrapper(extension.implementation),
+            logs.toMutableList(),
+            extension.fogPackages,
+            extension.generator,
+            className,
+            classContext.currentClassData.className,
+            extension.mode,
+            nextClassVisitor
+        )
+    }
+
+    override fun isInstrumentable(classData: ClassData): Boolean {
+        return true
+    }
+
+}
+
+fun Instrumentation.transformClassesWithStringFog(
+    namespace: String, stringFog: StringFogExtension
+) {
+    transformClassesWith(
+        SimpleStringFogClassVisitorFactory::class.java, InstrumentationScope.PROJECT
+    ) {
+        it.logs.set(arrayListOf())
+        it.extension.set(StringFogExtensionWrapper.get(stringFog))
+        it.className.set("$namespace.${SourceGeneratingTask.FOG_CLASS_NAME}")
+    }
+}

--- a/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/StringFogPlugin.kt
+++ b/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/StringFogPlugin.kt
@@ -1,7 +1,6 @@
 package com.github.megatronking.stringfog.plugin
 
 import com.android.build.api.instrumentation.FramesComputationMode
-import com.android.build.api.instrumentation.InstrumentationScope
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
@@ -74,12 +73,7 @@ class StringFogPlugin : Plugin<Project> {
                 throw IllegalArgumentException("Unable to resolve applicationId")
             }
 
-            val logs = mutableListOf<String>()
-            StringFogTransform.setParameters(stringfog, logs, "$applicationId.${SourceGeneratingTask.FOG_CLASS_NAME}")
-            variant.instrumentation.transformClassesWith(
-                StringFogTransform::class.java,
-                InstrumentationScope.PROJECT) {
-            }
+            variant.instrumentation.transformClassesWithStringFog(applicationId,stringfog)
             variant.instrumentation.setAsmFramesComputationMode(
                 FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS
             )

--- a/stringfog-interface/src/main/java/com/github/megatronking/stringfog/IKeyGenerator.java
+++ b/stringfog-interface/src/main/java/com/github/megatronking/stringfog/IKeyGenerator.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
  * @author Megatron King
  * @since 2022/1/14 22:15
  */
-public interface IKeyGenerator {
+public interface IKeyGenerator extends Serializable {
 
     /**
      * Generate a security key.


### PR DESCRIPTION
一个项目多项配置`StringFog`导致的Bug

一个项目里面多个`Project`都配置`StringFog`会导致找不到所需的`StringFog.java`  
提示`Missing class packageName.StringFog`,
这里的`packageName`是插件`apply`方法获取的最后一个`Project`

复现:

分别创建包名为`com.github.sample.A`和包名为`com.github.sample.B`的两个`Library`都配置`StringFog`,  
`ALibrary`打`release`包的时候会提示找不到`com.github.sample.B.StringFog`类

这里`BLibrary`是项目运行时插件获取到的最后一个`Project`,如果配置了三个`StringFog`分别是`A`,`B`,`C`
就会提示找不到`C`包名下的`StringFog.java`

原因:

`StringFogTransform`的数据都是通过静态变量赋值,`className`一直都是最后一个`Project`的包名,
配置一个没有这个问题