### PR TITLE
fix bugs caused by multiple configurations (static map for non-serializable parameters)

### DIFF
--- a/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/StringFogInstrumentationParams.kt
+++ b/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/StringFogInstrumentationParams.kt
@@ -1,0 +1,53 @@
+package com.github.megatronking.stringfog.plugin
+
+import com.android.build.api.instrumentation.InstrumentationParameters
+import com.github.megatronking.stringfog.StringFogWrapper
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import java.lang.ref.WeakReference
+import java.util.WeakHashMap
+
+abstract class StringFogInstrumentationParams : InstrumentationParameters {
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    @get:Input
+    abstract val className: Property<String>
+}
+
+private class NonSerializableParams(
+    val logs: MutableList<String>,
+    val implementation: StringFogWrapper
+)
+
+private val extensionForApplicationId = mutableMapOf<String, WeakReference<StringFogExtension>>()
+private val extensionNonSerializableParams = WeakHashMap<StringFogExtension, NonSerializableParams>()
+
+internal val StringFogInstrumentationParams.extension
+    get() = extensionForApplicationId[applicationId.get()]?.get()
+        ?: throw IllegalStateException("Extension has not been registered with setParameters")
+
+private val StringFogInstrumentationParams.nonSerializableParameters
+    get() = extension.let { extensionNonSerializableParams[it] }
+        ?: throw IllegalStateException("runtimeParameters have not been registered with setParameters")
+
+internal val StringFogInstrumentationParams.logs get() = nonSerializableParameters.logs
+
+internal val StringFogInstrumentationParams.implementation get() = nonSerializableParameters.implementation
+
+internal fun StringFogInstrumentationParams.setParameters(
+    applicationId: String,
+    extension: StringFogExtension,
+    logs: MutableList<String>,
+    className: String
+) {
+    this.applicationId.set(applicationId)
+    this.className.set(className)
+    extensionForApplicationId[applicationId] = WeakReference(extension)
+    extensionNonSerializableParams[extension] = NonSerializableParams(
+        logs = logs,
+        implementation = StringFogWrapper(extension.implementation)
+    )
+    logs.add("stringfog impl: " + extension.implementation)
+    logs.add("stringfog mode: " + extension.mode)
+}

--- a/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/StringFogPlugin.kt
+++ b/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/StringFogPlugin.kt
@@ -75,10 +75,16 @@ class StringFogPlugin : Plugin<Project> {
             }
 
             val logs = mutableListOf<String>()
-            StringFogTransform.setParameters(stringfog, logs, "$applicationId.${SourceGeneratingTask.FOG_CLASS_NAME}")
             variant.instrumentation.transformClassesWith(
                 StringFogTransform::class.java,
-                InstrumentationScope.PROJECT) {
+                InstrumentationScope.PROJECT
+            ) { params ->
+                params.setParameters(
+                    applicationId,
+                    stringfog,
+                    logs,
+                    "$applicationId.${SourceGeneratingTask.FOG_CLASS_NAME}"
+                )
             }
             variant.instrumentation.setAsmFramesComputationMode(
                 FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS

--- a/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/StringFogTransform.kt
+++ b/stringfog-gradle-plugin/src/main/java/com/github/megatronking/stringfog/plugin/StringFogTransform.kt
@@ -12,32 +12,18 @@ import org.gradle.api.tasks.Input
 import org.objectweb.asm.ClassVisitor
 import java.io.File
 
-abstract class StringFogTransform : AsmClassVisitorFactory<InstrumentationParameters.None> {
-
-    companion object {
-        private lateinit var className: String
-        private lateinit var extension: StringFogExtension
-        private lateinit var logs: List<String>
-        private lateinit var implementation: StringFogWrapper
-
-        fun setParameters(extension: StringFogExtension, logs: List<String>, className: String) {
-            StringFogTransform.extension = extension
-            StringFogTransform.className = className
-            StringFogTransform.logs = logs
-            implementation = StringFogWrapper(extension.implementation)
-            logs.plus("stringfog impl: " + extension.implementation)
-            logs.plus("stringfog mode: " + extension.mode)
-        }
-    }
+abstract class StringFogTransform : AsmClassVisitorFactory<StringFogInstrumentationParams> {
 
     override fun createClassVisitor(
         classContext: ClassContext,
         nextClassVisitor: ClassVisitor
     ): ClassVisitor {
-        return ClassVisitorFactory.create(
-            implementation, logs, extension.fogPackages, extension.kg, className,
-            classContext.currentClassData.className, extension.mode, nextClassVisitor
-        )
+        return with(parameters.get()) {
+            ClassVisitorFactory.create(
+                implementation, logs, extension.fogPackages, extension.kg, className.get(),
+                classContext.currentClassData.className, extension.mode, nextClassVisitor
+            )
+        }
     }
 
     override fun isInstrumentable(classData: ClassData): Boolean {


### PR DESCRIPTION
This solves the same issues as [PR 140](https://github.com/MegatronKing/StringFog/pull/140) but by looking up parameters by `applicationId` instead of forcing the them to be serializable.